### PR TITLE
Prevented withRequiredValidator from being passed as prop to TextField.

### DIFF
--- a/src/TextValidator.jsx
+++ b/src/TextValidator.jsx
@@ -8,7 +8,7 @@ export default class TextValidator extends ValidatorComponent {
 
     render() {
         // eslint-disable-next-line
-        const { errorMessages, validators, requiredError, errorText, validatorListener, ...rest } = this.props;
+        const { errorMessages, validators, requiredError, errorText, validatorListener, withRequiredValidator, ...rest } = this.props;
         const { isValid } = this.state;
         return (
             <TextField


### PR DESCRIPTION
Prevents the following warning when using withRequiredValidator with the TextValidator component: "Warning: React does not recognize the `withRequiredValidator` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `withrequiredvalidator` instead. If you accidentally passed it from a parent component, remove it from the DOM element."