### PR TITLE
Prevented passing withRequiredValidator as prop to TextField.

### DIFF
--- a/src/TextValidator.jsx
+++ b/src/TextValidator.jsx
@@ -8,7 +8,7 @@ export default class TextValidator extends ValidatorComponent {
 
     render() {
         // eslint-disable-next-line
-        const { errorMessages, validators, requiredError, helperText, validatorListener, ...rest } = this.props;
+        const { errorMessages, validators, requiredError, helperText, validatorListener, withRequiredValidator, ...rest } = this.props;
         const { isValid } = this.state;
         return (
             <TextField


### PR DESCRIPTION
Same change as PR for main branch, but adapted to v1 branch.