### PR TITLE
Allow setting error externally.

### DIFF
--- a/src/SelectValidator.jsx
+++ b/src/SelectValidator.jsx
@@ -9,6 +9,7 @@ export default class SelectValidator extends ValidatorComponent {
     render() {
         /* eslint-disable no-unused-vars */
         const {
+            error,
             errorMessages,
             validators,
             requiredError,
@@ -22,7 +23,7 @@ export default class SelectValidator extends ValidatorComponent {
             <TextField
                 {...rest}
                 select
-                error={!isValid}
+                error={!isValid || error}
                 helperText={(!isValid && this.getErrorMessage()) || helperText}
             />
         );

--- a/src/TextValidator.jsx
+++ b/src/TextValidator.jsx
@@ -9,6 +9,7 @@ export default class TextValidator extends ValidatorComponent {
     render() {
         /* eslint-disable no-unused-vars */
         const {
+            error,
             errorMessages,
             validators,
             requiredError,
@@ -21,7 +22,7 @@ export default class TextValidator extends ValidatorComponent {
         return (
             <TextField
                 {...rest}
-                error={!isValid}
+                error={!isValid || error}
                 helperText={(!isValid && this.getErrorMessage()) || helperText}
             />
         );


### PR DESCRIPTION
MaterialUI's TextField accepts an error prop, but this wasn't being passed on by TextValidator. This PR rectifies that, allowing the error state to be set manually. This makes sense, as you can already set the helperText manually.