### PR TITLE
ISSUE FIX: React does not recognize the containerProps

### DIFF
--- a/src/SelectValidator.jsx
+++ b/src/SelectValidator.jsx
@@ -15,6 +15,7 @@ export default class SelectValidator extends ValidatorComponent {
             helperText,
             validatorListener,
             withRequiredValidator,
+            containerProps,
             ...rest
         } = this.props;
         const { isValid } = this.state;

--- a/src/TextValidator.jsx
+++ b/src/TextValidator.jsx
@@ -15,6 +15,7 @@ export default class TextValidator extends ValidatorComponent {
             helperText,
             validatorListener,
             withRequiredValidator,
+            containerProps,
             ...rest
         } = this.props;
         const { isValid } = this.state;


### PR DESCRIPTION
While adding containerProps in TextValidator or SelectValidator, we got warning as shown in image below. 

![photo6131849930495601212](https://user-images.githubusercontent.com/4599662/88893735-80f10e00-d266-11ea-982a-eb73fcf8060b.jpg)

Warning:
![photo6131849930495601211](https://user-images.githubusercontent.com/4599662/88893858-b5fd6080-d266-11ea-9916-f80ec2240b50.jpg)

Fix has been applied. Sending PR request. 

Please review. 

Thanks,
Sagar
