### PR TITLE
Updated react-form-validator-core to 2.0.1, removing old context API

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/NewOldMax/react-material-ui-form-validator#readme",
   "dependencies": {
-    "react-form-validator-core": "1.1.2",
+    "react-form-validator-core": "2.0.1",
     "prop-types": "^15.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hey!

I have a project where I still use MUI v5, would like to update this so that it resolves npm warnings that appear when installing this, since I am using React 17, where old context API is no longer supported.

Saw that the changes from 1.1.2 -> 2.0.1 is only the context api removal, so it should still be compatible with the same dependencies (react 17 or 18, mui5, etc.). Open to modifying the versioning to be a minor one in case this is breaking for react@<17 users

This shouldn't be merged as is, since master is on v4.0.1, but would appreciate if you created a branch for v3.0.1 on which to merge in, and then publish an update to the package.

Thanks in advance! Happy to make any changes on this to allow merging.